### PR TITLE
surface the app user id into the token subject

### DIFF
--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ func main() {
 		// TODO: Add support for Redis
 		store:                  store,
 		oidcStateStore:         oidcStateStore,
-		rolesServiceUrl:        c.RolesServiceUrl.String(),
+		appIdentityServiceUrl:  c.AppIdentityServiceUrl.String(),
 		afterLoginRedirectURL:  c.AfterLoginURL.String(),
 		homepageURL:            c.HomepageURL.String(),
 		afterLogoutRedirectURL: c.AfterLogoutURL.String(),

--- a/roles.go
+++ b/roles.go
@@ -10,7 +10,12 @@ import (
 
 type Roles = []string
 
-func getRolesByEmail(svcUrl string, serviceToken string, idTokenHeader string, email string) *Roles {
+type Identity struct {
+	ID    string `json:"id"`
+	Roles Roles  `json:"roles"`
+}
+
+func getIdentityByEmail(svcUrl string, serviceToken string, idTokenHeader string, email string) *Identity {
 	svcByteString := []byte(svcUrl)
 	url := fmt.Sprintf("%s/%s", bytes.TrimRight(svcByteString, "/"), email)
 
@@ -25,8 +30,8 @@ func getRolesByEmail(svcUrl string, serviceToken string, idTokenHeader string, e
 	}
 	defer r.Body.Close()
 
-	roles := new(Roles)
-	json.NewDecoder(r.Body).Decode(roles)
+	identity := new(Identity)
+	json.NewDecoder(r.Body).Decode(identity)
 
-	return roles
+	return identity
 }

--- a/roles.go
+++ b/roles.go
@@ -11,8 +11,10 @@ import (
 type Roles = []string
 
 type Identity struct {
-	ID    string `json:"id"`
-	Roles Roles  `json:"roles"`
+	ID        string `json:"id"`
+	Roles     Roles  `json:"roles"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
 }
 
 func getIdentityByEmail(svcUrl string, serviceToken string, idTokenHeader string, email string) *Identity {

--- a/settings.go
+++ b/settings.go
@@ -22,14 +22,14 @@ type config struct {
 	OIDCStateStorePath      string   `split_words:"true" default:"/var/lib/authservice/data.db"`
 
 	// General
-	AuthserviceURLPrefix *url.URL `required:"true" split_words:"true"`
-	RolesServiceUrl      *url.URL `split_words:"true" envconfig:"ROLES_SERVICE_URL"`
-	SkipAuthURLs         []string `split_words:"true" envconfig:"SKIP_AUTH_URLS"`
-	AuthHeader           string   `split_words:"true" default:"Authorization"`
-	Audiences            []string `default:"istio-ingressgateway.istio-system.svc.cluster.local"`
-	HomepageURL          *url.URL `split_words:"true"`
-	AfterLoginURL        *url.URL `split_words:"true"`
-	AfterLogoutURL       *url.URL `split_words:"true"`
+	AuthserviceURLPrefix  *url.URL `required:"true" split_words:"true"`
+	AppIdentityServiceUrl *url.URL `split_words:"true" envconfig:"APP_IDENTITY_SERVICE_URL"`
+	SkipAuthURLs          []string `split_words:"true" envconfig:"SKIP_AUTH_URLS"`
+	AuthHeader            string   `split_words:"true" default:"Authorization"`
+	Audiences             []string `default:"istio-ingressgateway.istio-system.svc.cluster.local"`
+	HomepageURL           *url.URL `split_words:"true"`
+	AfterLoginURL         *url.URL `split_words:"true"`
+	AfterLogoutURL        *url.URL `split_words:"true"`
 
 	// Identity Headers
 	UserIDHeader string `split_words:"true" default:"kubeflow-userid" envconfig:"USERID_HEADER"`


### PR DESCRIPTION
## Summary

Updates the structure of the interaction with an external application (hyperdrive-iam) to surface the id of the user.

## Testing

Followed the same auth flows as supported previously with the changes, checked that when the IAM service is returning a data shape in accordance to this contract for identity information:

### Keys Added

| jwt claim  |  type | origin value |
| ------------- | ------------- | ------------- |
| `sub`  | **string** | IAM `user.id`  |
| `externalSub`  | **string** | IDP `sub`  |
| `roles`  | **string[]** | IAM `user.roles`  |
| `firstName`  | **string** | IAM `user.firstName`  |
| `lastName`  | **string** | IAM `user.lastName`  |

![image](https://user-images.githubusercontent.com/2242258/120836687-73ae4b00-c52b-11eb-85a8-ac3a59e69071.png)

## Notes

Will require a change to the env var from `ROLES_SERVICE_URL` to  `APP_IDENTITY_SERVICE_URL` for the service endpoint to IAM, as it is not not just roles its the identity of the user of the application (id + roles).
https://gohypergiant.atlassian.net/browse/EAIP-730

Will also require a change to the IAM service to adapt this work, as I just locally stubbed this in to showcase the concept.
https://gohypergiant.atlassian.net/browse/EAIP-728

## Ticket(s)

- https://gohypergiant.atlassian.net/browse/EAIP-729